### PR TITLE
Adding Title and description to content model

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -46,7 +46,9 @@ class ContentsController < ApplicationController
   end
 
   def content_params
-    params.require(:content).permit(:url,
+    params.require(:content).permit(:title,
+      :description,
+      :url,
       :status,
       :size,
       :content_type,

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -13,6 +13,8 @@ class Content < ActiveRecord::Base
 
   attr_accessor :maslow_need_ids
 
+  validates :title, presence: true
+
   def maslow_need_ids
     content_needs.any? ? content_needs.map(&:need_id).join(",") : nil
   end

--- a/app/views/contents/_form.html.slim
+++ b/app/views/contents/_form.html.slim
@@ -1,6 +1,8 @@
 .form-margin.well
   = simple_form_for content,
                     html: { class: 'form-horizontal form-container' } do |f|
+    = f.input :title
+    = f.input :description
     = f.input :url, as: :string
     = f.input :platform, as: :select, collection: Content::PLATFORMS, include_blank: false
     = f.input :size

--- a/app/views/contents/index.html.slim
+++ b/app/views/contents/index.html.slim
@@ -13,6 +13,8 @@
     = paginate contents
 
     table.table
+      th title
+      th description
       th URL
       th Size
       th Platform
@@ -23,14 +25,18 @@
       - contents.each do |content|
         tr
           td
+            = content.title
+          td
+            = content.description
+          td
             - if policy(Content).edit?
               = link_to content.url, [:edit, content]
             - else
               = content.url
           td
-            = content.size    
+            = content.size
           td
-            = content.platform          
+            = content.platform
           td
             = content.status
           td

--- a/db/migrate/20140123155211_add_title_and_description_to_content.rb
+++ b/db/migrate/20140123155211_add_title_and_description_to_content.rb
@@ -1,0 +1,6 @@
+class AddTitleAndDescriptionToContent < ActiveRecord::Migration
+  def change
+    add_column :contents, :title, :string, null: false
+    add_column :contents, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131203173258) do
+ActiveRecord::Schema.define(version: 20140123155211) do
 
   create_table "comments", force: true do |t|
     t.integer  "user_id"
@@ -60,6 +60,8 @@ ActiveRecord::Schema.define(version: 20131203173258) do
     t.datetime "updated_at"
     t.string   "platform"
     t.integer  "size"
+    t.string   "title",        null: false
+    t.text     "description"
   end
 
   create_table "source_url_content_plans", force: true do |t|

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -2,6 +2,7 @@
 
 FactoryGirl.define do
   factory :content do
+    title "Content Title"
     url "MyText"
     content_type "MyString"
     status "MyString"

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe Content do
+  it "should not be valid without a title" do
+    content = FactoryGirl.build :content, title: nil
+    content.valid?.should be_false
+    content.errors.messages[:title].should include("can't be blank")
+  end
+  it "should be valid with a title" do
+    FactoryGirl.build(:content).should be_valid
+  end
+end


### PR DESCRIPTION
add columns `title` and `description` to _contents_ table
validate presence of title on Content
show title and description in views
permitting title and description in the params
specs for validate Content#title
