### PR TITLE
changed implementations to support filter by due date on dashboard

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,8 @@ class HomeController < ApplicationController
   skip_before_filter :require_signin_permission!, only: :dashboard_data
 
   def index
-    @tags = Content.tag_counts_on(:tags).to_a.sort{|a,b| a.name <=> b.name}
+    @contents = ContentPlan.due_date(params[:q], params[:year]).contents
+    @tags = @contents.tag_counts_on(:tags).to_a.sort{|a,b| a.name <=> b.name}
   end
 
   def chart

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -58,8 +58,9 @@ class Content < ActiveRecord::Base
   def self.percentages_for(options)
     tag = options.fetch(:tag) { raise ArgumentError.new("#percentages_for expects tag: as part of options hash") }
     platform = options.fetch(:platform) { raise ArgumentError.new("#percentages_for expects platform: as part of options hash") }
+    contents = options.fetch(:contents) { raise ArgumentError.new("#percentages_for expecs contents: as part of options hash") }
 
-    scope = scoped.where(platform: platform).tagged_with(tag.name)
+    scope = contents.where(platform: platform).tagged_with(tag.name)
     total = scope.sum(:size)
     STATUSES[platform].inject({}) do |hash, status|
       hash.tap do |hash|

--- a/app/models/content_plan.rb
+++ b/app/models/content_plan.rb
@@ -10,6 +10,16 @@ class ContentPlan < ActiveRecord::Base
   validates :title, presence: true
   validates :ref_no, presence: true
 
+  scope :due_date, ->(quarter, year) {
+    scope = all
+    scope = scope.where(due_quarter: quarter) if quarter.present?
+    scope = scope.where(due_year: year) if year.present?
+    scope
+  }
+  scope :contents, -> {
+    Content.where id: all.map(&:content_plan_contents).flatten.map(&:content_id).uniq
+  }
+
   has_many :tasks,    -> { order(created_at: :desc) }, dependent: :destroy
   has_many :comments, -> { order(created_at: :desc) }, dependent: :destroy, as: :commentable
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,6 +1,10 @@
 .row
   .span12
     = link_to "View as chart", chart_path, class: 'btn pull-right'
+    = form_tag root_path, method: :get, class: "form-inline search-form" do
+      = select_tag :q, options_for_select(ContentPlan::QUARTERS.map {|x| ["Quarter #{x}", x]}, params[:q]), prompt: "Quarter"
+      = select_tag :year, options_for_select(ContentPlan::YEARS, params[:year]), prompt: "Year"
+      = submit_tag "Filter", class: "btn"
   .span12
     - @tags.each do |tag|
       .tag-box.span3
@@ -10,5 +14,5 @@
           .platform
             = platform
             .progress
-              - Content.percentages_for(tag: tag, platform: platform).each do |status, percentage|
+              - Content.percentages_for(tag: tag, platform: platform, contents: @contents).each do |status, percentage|
                 div[class="#{progress_bar_class_for status}" style="width: #{percentage}%" title="#{status}: #{percentage}%" data-tooltip=true data-placement="bottom"]


### PR DESCRIPTION
- ContentPlan defines scopes for `due_date` and `contents`
- Content#percentages_for now receives `contents` as part of options
  hash, where it’s going to generate percentages
- Add form to home#index template
