### PR TITLE
Use the organisations API from whitehall instead of the need_api

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
 
   def content_organisations(organisations)
     return if organisations.compact.empty?
-    organisations.map(&:abbreviation_or_name).join ", "
+    organisations.map(&:abbreviation_or_title).join ", "
   end
 
   def collection_links(coll, f_name, f_link, separator = ", ")

--- a/config/initializers/organisations_api.rb
+++ b/config/initializers/organisations_api.rb
@@ -1,0 +1,3 @@
+require 'gds_api/organisations'
+
+ContentPlanner.organisations_api = GdsApi::Organisations.new( Plek.current.find('whitehall-admin') )

--- a/lib/content_planner.rb
+++ b/lib/content_planner.rb
@@ -1,5 +1,6 @@
 module ContentPlanner
   mattr_accessor :needs_api
+  mattr_accessor :organisations_api
 
-  module_function :needs_api
+  module_function
 end


### PR DESCRIPTION
The use of the need API was a bit of a hack, we should use the proper endpoint.

This means whitehall will have to be running too.

Modified the `id` of the org to be the slug to maintain compatibility with the old need_api version of orgs

Also remove some code which was not used after the lruchache was implemented
