### PR TITLE
Gds api should use real requests only in prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ pickle-email-*.html
 
 # vim artifacts
 **.swp
+
+.ruby-gemset

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development do
   gem "rack-mini-profiler"
   gem "bullet"
   gem "thin"
+  gem 'therubyracer', platforms: :ruby
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
       activesupport (>= 3.0.0)
     kgio (2.8.1)
     kramdown (0.13.8)
+    libv8 (3.16.14.3)
     link_header (0.0.8)
     lockfile (2.1.0)
     logstash-event (1.1.5)
@@ -253,6 +254,7 @@ GEM
     rainbow (2.0.0)
     raindrops (0.12.0)
     rake (10.1.0)
+    ref (1.0.5)
     request_store (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -316,6 +318,9 @@ GEM
     temple (0.6.7)
     term-ansicolor (1.2.2)
       tins (~> 0.8)
+    therubyracer (0.12.1)
+      libv8 (~> 3.16.14.0)
+      ref
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -398,6 +403,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   slim
+  therubyracer
   thin
   turbolinks
   uglifier (>= 1.3.0)

--- a/config/initializers/organisations_api.rb
+++ b/config/initializers/organisations_api.rb
@@ -1,3 +1,10 @@
 require 'gds_api/organisations'
 
-ContentPlanner.organisations_api = GdsApi::Organisations.new( Plek.current.find('whitehall-admin') )
+if Rails.env.production?
+  ContentPlanner.organisations_api = GdsApi::Organisations.new( Plek.current.find('whitehall-admin') )
+else
+  require "#{Rails.root}/spec/spec_helper"
+
+  ContentPlanner.needs_api = MockNeedsApi.new
+  ContentPlanner.organisations_api = MockOrganisationsApi.new
+end


### PR DESCRIPTION
1. Set ContentPlanner.organisations_api to use real requests only in prod env
2. Added gem 'therubyracer', platforms: :ruby to dev env to avoid exec.js error on lunix machines
3. Added .ruby-gemset to .gitignore
