### PR TITLE
[GDS API] should use real calls only in prod env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ pickle-email-*.html
 
 # vim artifacts
 **.swp
+
+.ruby-gemset

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_script:
 before_install:
   - cp config/database.travis.yml config/database.yml
 script:
-  - RAILS_ENV=test bundle exec rake db:create
   - RAILS_ENV=test bundle exec rake db:migrate
   - RAILS_ENV=test bundle exec rake spec
 rvm:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,9 @@
 ContentPlanner::Application.configure do
+  require "#{config.root}/spec/support/mock_needs_api"
+  require "#{config.root}/spec/support/mock_organisations_api"
+  require 'gds_api/need_api'
+  require 'gds_api/organisations'
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -39,8 +44,12 @@ ContentPlanner::Application.configure do
   config.action_mailer.default_url_options = { host: "http://10.1.1.254:3058/" }
 
   config.after_initialize do
-    Bullet.enable = true
-    Bullet.rails_logger = true
-    Bullet.add_footer = true
+    if ENV["USE_API"]
+      ContentPlanner.needs_api = GdsApi::NeedApi.new( Plek.current.find('need-api'), API_CLIENT_CREDENTIALS )
+      ContentPlanner.organisations_api = GdsApi::Organisations.new( Plek.current.find('whitehall-admin') )
+    else
+      ContentPlanner.needs_api = MockNeedsApi.new
+      ContentPlanner.organisations_api = MockOrganisationsApi.new
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,7 @@
 ContentPlanner::Application.configure do
+  require 'gds_api/need_api'
+  require 'gds_api/organisations'
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -83,4 +86,9 @@ ContentPlanner::Application.configure do
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
   config.logstasher.suppress_app_log = true
+
+  config.after_initialize do
+    ContentPlanner.needs_api = GdsApi::NeedApi.new( Plek.current.find('need-api'), API_CLIENT_CREDENTIALS )
+    ContentPlanner.organisations_api = GdsApi::Organisations.new( Plek.current.find('whitehall-admin') )
+  end
 end

--- a/config/initializers/needs_api.rb
+++ b/config/initializers/needs_api.rb
@@ -1,4 +1,0 @@
-require 'gds_api/need_api'
-
-ContentPlanner.needs_api = GdsApi::NeedApi.new( Plek.current.find('need-api'), API_CLIENT_CREDENTIALS )
-

--- a/config/initializers/organisations_api.rb
+++ b/config/initializers/organisations_api.rb
@@ -1,3 +1,0 @@
-require 'gds_api/organisations'
-
-ContentPlanner.organisations_api = GdsApi::Organisations.new( Plek.current.find('whitehall-admin') )


### PR DESCRIPTION
Mock the API Calls in development, optionally allow the use of the APIs with the following: 

USE_API=true ./startup.sh
