### PR TITLE
[#68269654] Dashboard: content plans list should be ordered by ref_no

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,8 @@ class HomeController < ApplicationController
   skip_before_filter :require_signin_permission!, only: :dashboard_data
 
   def index
-    @content_plans = ContentPlan.due_date(params[:q], params[:year]).includes(:content_plan_contents, :contents)
+    @content_plans = ContentPlan.due_date(params[:q], params[:year])
+                                .order(ref_no: :asc)
+                                .includes(:content_plan_contents, :contents)
   end
 end


### PR DESCRIPTION
Dashboard: content plans list should be ordered by ref_no

https://www.pivotaltracker.com/story/show/68269654
