### PR TITLE
68637480 comments ability to edit and delete

### DIFF
--- a/app/assets/stylesheets/views/comments.css.scss
+++ b/app/assets/stylesheets/views/comments.css.scss
@@ -9,3 +9,10 @@
 span.created_at{
   float: right;
 }
+
+.edit_comment_form {
+  textarea {
+    width: 500px;
+    height: 150px;
+  }
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,6 +2,8 @@ class CommentsController < ApplicationController
   expose(:comment, attributes: :comment_params)
   expose(:comments)
 
+  before_action :require_to_be_owner!, only: [:edit, :update, :destroy]
+
   def create
     if comment.save(comment_params)
       redirect_to comment.commentable
@@ -10,15 +12,39 @@ class CommentsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
   def update
     if comment.update(comment_params)
-      redirect_to comment.commentable
+      redirect_to comment.commentable, notice: "Comment updated"
     else
       render :edit
     end
   end
 
+  def destroy
+    comment.destroy
+    redirect_to comment.commentable, notice: "Comment deleted"
+  end
+
+  private
+
   def comment_params
     params.require(:comment).permit(:message, :user_id, :commentable_id, :commentable_type)
+  end
+
+  def require_to_be_owner!
+    comment_policy = CommentPolicy.new(current_user, comment)
+
+    unless comment_policy.can_update_or_remove?
+      notice = if !comment_policy.comment_author?
+        "You have no permissions to #{action_name} this comment"
+      elsif !comment_policy.comment_is_just_created?
+        "Comment can be updated or deleted only in 5 minutes after posting"
+      end
+
+      redirect_to comment.commentable, notice: notice
+    end
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,0 +1,28 @@
+class CommentPolicy < Struct.new(:user, :comment)
+  def edit?
+    can_update_or_remove?
+  end
+
+  def update?
+    can_update_or_remove?
+  end
+
+  def destroy?
+    can_update_or_remove?
+  end
+
+  def can_update_or_remove?
+    user.gds_editor? &&
+    comment_author? &&
+    comment_is_just_created?
+  end
+
+  def comment_author?
+    comment.user == user
+  end
+
+  def comment_is_just_created?
+    5.minutes.ago < comment.created_at &&
+    comment.created_at < Time.zone.now
+  end
+end

--- a/app/views/comments/_action_links.html.slim
+++ b/app/views/comments/_action_links.html.slim
@@ -1,0 +1,13 @@
+- if policy(comment).can_update_or_remove?
+  .pull-right
+    - if policy(comment).update?
+      = link_to edit_comment_path(comment),
+                class: "btn btn-mini",
+                data: { action: "edit_comment", confirm: "Are you sure?" } do
+        i.icon-pencil
+    - if policy(comment).destroy?
+      = link_to comment_path(comment),
+                method: :delete,
+                class: "btn btn-mini",
+                data: { action: "delete_comment", confirm: "Are you sure?" } do
+        i.icon-trash

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,6 +1,7 @@
-li.comment
+li.comment id="#{dom_id(comment)}"
   .message
     = govspeak comment.message
+  = render 'comments/action_links', comment: comment
   span.name
     = link_to comment.user, comment.user
     |,

--- a/app/views/comments/edit.html.slim
+++ b/app/views/comments/edit.html.slim
@@ -1,0 +1,8 @@
+= breadcrumb [comment.commentable.to_s, comment.commentable], "Edit Comment"
+
+.container-fluid
+  .row-fluid
+    .span12
+      h2 Edit Comment
+      .form-margin.well.edit_comment_form
+        = render 'form'

--- a/spec/features/comments_from_content_spec.rb
+++ b/spec/features/comments_from_content_spec.rb
@@ -1,17 +1,115 @@
 require "spec_helper"
 
 feature "Add comments from content" do
-  before { create :user, :gds_editor }
+  let!(:user) { create :user, :gds_editor }
+  let!(:content) { create :content }
+  let!(:comment) {
+    create :comment, user: user, commentable: content
+  }
+
+  let(:comment_text) { "Test comment" }
+  let(:updated_comment_text) { "Updated test comment" }
+
+  before {
+    visit content_path(content)
+  }
 
   scenario "add comment from content" do
-    content = create :content
-
-    visit content_path(content)
-    comment_text = "Test comment"
     fill_in "comment_message", with: comment_text
     click_on "Create Comment"
 
     current_path.should eq(content_path(content))
-    page.should have_text(comment_text)
+    expect_to_see comment_text
+  end
+
+  describe "update and delete links" do
+    include RSpec::Rails::RequestExampleGroup
+
+    describe "5 minutes passed" do
+      before {
+        comment.created_at = comment.created_at - 5.minutes
+        comment.save
+
+        visit content_path(content)
+      }
+
+      it "comment should have no edit or delete links" do
+        comment_has_not_edit_and_delete_links
+      end
+
+      it "should not allow to update or delete comment" do
+        doesnt_allow_to_update_or_delete_comment("time_passed")
+      end
+    end
+
+    describe "not owner of comment" do
+      let!(:another_user) { create :user, :gds_editor }
+
+      before {
+        comment.user = another_user
+        comment.save
+
+        visit content_path(content)
+      }
+
+      it "comment should have no edit or delete links" do
+        comment_has_not_edit_and_delete_links
+      end
+
+      it "should not allow to update or delete comment" do
+        doesnt_allow_to_update_or_delete_comment("permissions")
+      end
+    end
+  end
+
+  scenario "edit comment from content" do
+    within(dom_id_selector(comment)) do
+      click_on "edit_comment"
+    end
+
+    fill_in "comment_message", with: updated_comment_text
+    click_on "Update Comment"
+
+    current_path.should eq(content_path(content))
+    expect_to_see updated_comment_text
+    expect_to_see "Comment updated"
+  end
+
+  scenario "delete comment from content" do
+    expect {
+      within(dom_id_selector(comment)) do
+        click_on "delete_comment"
+      end
+    }.to change { user.reload.comments.count }.from(1).to(0)
+
+    expect_to_see "Comment deleted"
+    current_path.should eq(content_path(content))
+    expect_to_see_no comment.message
+  end
+
+  private
+
+  def comment_has_not_edit_and_delete_links
+    within(dom_id_selector(comment)) do
+      expect(page).to_not have_selector("a[data-action='edit_comment']")
+      expect(page).to_not have_selector("a[data-action='delete_comment']")
+    end
+  end
+
+  def doesnt_allow_to_update_or_delete_comment(restrict_rule)
+    visit edit_comment_path(comment)
+    expect_to_see notice_by_restrict_rule(restrict_rule)
+
+    expect {
+      delete comment_path(comment)
+    }.to_not change { Comment.count }.by(-1)
+  end
+
+  def notice_by_restrict_rule(restrict_rule)
+    if restrict_rule == 'permissions'
+     "You have no permissions to edit this comment"
+    else
+      "Comment can be updated or deleted only in 5 minutes after posting"
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include FeaturesHelpers, type: :feature
   config.include ExpectationHelper, type: :feature
+  config.include ClickOnHelper, type: :feature
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/support/click_on_helper.rb
+++ b/spec/support/click_on_helper.rb
@@ -1,0 +1,40 @@
+module ClickOnHelper
+  # Examples
+  #
+  #   click_on '.new_foo'   # <a href='#' class='new_foo'>foo</a>
+  #   click_on '#save_foo'  # <a href='#' id='save_foo'>foo</a>
+  #   click_on ':#save_foo' # <a href='#save_foo'>foo</a>
+  #   click_on '/some/url'  # <a href='/some/url'>foo</a>
+  #   click_on '+ New Foo'  # <a href='#'>+ New Foo</a>
+  #   click_on 'leave_feedback'  # <a href='#' data-action='leave_feedback'>Foo</a>
+  #
+  def click_on(locator)
+    el = case locator[0]
+         when ':'
+           val = locator[1..-1]
+
+           find %(a[href="#{val}"])
+
+         when '.', '#'
+           find locator
+
+         else
+           if locator =~ /\//
+            find %(a[href="#{locator}"])
+
+           else
+             find %(a[data-action="#{locator}"], input[data-action="#{locator}"])
+           end
+         end
+
+    if el
+      el.click
+
+    else
+      super locator
+    end
+
+  rescue Capybara::ElementNotFound, Nokogiri::CSS::SyntaxError
+    super locator
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/68637480
- added base edit and update functionality
- added comment permissions policy via pundit
- added Rspec checks on edit and delete comment
- added Rspec checks for permission rules:
  - check on comment owner
  - check on time passed (comment can be updated or deleted only in 5 minutes after posting)
