### PR TITLE
6800299 comments ability to reply

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -1,0 +1,14 @@
+(function() {
+  CommentsReplyInit = function() {
+    $(document).on("click", ".reply_comment_link", function () {
+      $(".reply_comment_form").addClass("hidden");
+      $(this).parents(".comment").find(".reply_comment_form").removeClass("hidden");
+
+      return false;
+    });
+  };
+
+  $(document).ready(CommentsReplyInit);
+  $(document).on("page:load", CommentsReplyInit);
+
+}).call(this);

--- a/app/assets/stylesheets/views/comments.css.scss
+++ b/app/assets/stylesheets/views/comments.css.scss
@@ -16,3 +16,19 @@ span.created_at{
     height: 150px;
   }
 }
+
+.reply_comment_form {
+  clear: both;
+  margin-left: 30px;
+  padding-right: 13px;
+  margin-top: 0px;
+  padding-top: 15px;
+
+  .btn {
+    margin-right: -13px;
+  }
+}
+
+.comment_children {
+  list-style-type: none;
+}

--- a/app/interactors/comments/reply.rb
+++ b/app/interactors/comments/reply.rb
@@ -1,0 +1,54 @@
+module Comments
+  class Reply
+    attr_reader :comment, :comment_owner, :reply_comment, :reply_params, :success
+
+    def initialize(comment, reply_params)
+      @comment = comment
+      @comment_owner = comment.user
+      @reply_params = reply_params
+
+      @reply_comment = comment.children.new(reply_params)
+    end
+
+    def run
+      persist!
+
+      if success?
+        unless reply_comment.user == comment_owner
+          notify_parent_comment_owner!
+        end
+
+        notify_other_reply_recipients!
+      end
+
+      self
+    end
+
+    def persist!
+      reply_comment.commentable = comment.commentable
+      @success = reply_comment.save
+    end
+
+    def success?
+      @success
+    end
+
+    def errors
+      reply_comment.errors.full_messages.join(', ')
+    end
+
+    def notify_parent_comment_owner!
+      CommentMailer.reply_notification(reply_comment,
+                                       comment_owner).deliver!
+    end
+
+    def notify_other_reply_recipients!
+      reply_recipients = comment.reply_recipients.reject { |u| u == reply_comment.user }
+
+      reply_recipients.each do |notified_recipient|
+        CommentMailer.reply_notification(reply_comment,
+                                         notified_recipient).deliver!
+      end
+    end
+  end
+end

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -7,4 +7,17 @@ class CommentMailer < ActionMailer::Base
     @url = comment.commentable.class == ContentPlan ? content_plan_url(comment.commentable) : content_url(comment.commentable)
     mail to: @user.email, subject: "#{@comment.user} commented on #{@comment.commentable}"
   end
+
+  def reply_notification(reply_comment, notified_user)
+    @reply_comment = reply_comment
+    @replied_person = reply_comment.user
+    @notified_user = notified_user
+    @commentable = reply_comment.commentable
+
+    @url = comment_url(@reply_comment.parent)
+
+    @subject = "#{@replied_person} replied on comment on #{@commentable}"
+
+    mail to: @notified_user.email, subject: @subject
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,13 +1,31 @@
 class Comment < ActiveRecord::Base
   belongs_to :user
   belongs_to :commentable, polymorphic: true
+  belongs_to :parent, class_name: "Comment"
+
+  has_many :children, class_name: "Comment",
+                      foreign_key: :parent_id
 
   validates :commentable_id, presence: true
   validates :commentable_type, presence: true
 
-  after_create :notify_users
+  after_create :notify_users, if: "root?"
+
+  scope :roots, -> { where parent_id: nil }
 
   def notify_users
     CommentNotifier.new(self)
+  end
+
+  def root?
+    !child?
+  end
+
+  def child?
+    parent.present?
+  end
+
+  def reply_recipients
+    children.map(&:user).uniq
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -12,7 +12,6 @@ class CommentPolicy < Struct.new(:user, :comment)
   end
 
   def can_update_or_remove?
-    user.gds_editor? &&
     comment_author? &&
     comment_is_just_created?
   end
@@ -24,5 +23,9 @@ class CommentPolicy < Struct.new(:user, :comment)
   def comment_is_just_created?
     5.minutes.ago < comment.created_at &&
     comment.created_at < Time.zone.now
+  end
+
+  def reply?
+    comment.root?
   end
 end

--- a/app/views/comment_mailer/reply_notification.html.slim
+++ b/app/views/comment_mailer/reply_notification.html.slim
@@ -1,0 +1,7 @@
+p = "Hi, #{@notified_user}"
+
+p = @subject
+
+p = @reply_comment.message
+
+= link_to 'View', @url

--- a/app/views/comment_mailer/reply_notification.text.slim
+++ b/app/views/comment_mailer/reply_notification.text.slim
@@ -1,0 +1,7 @@
+= "Hi, #{@notified_user}\n"
+
+= "#{@subject}\n"
+
+= "#{@reply_comment.message}\n"
+
+= @url

--- a/app/views/comments/_action_links.html.slim
+++ b/app/views/comments/_action_links.html.slim
@@ -1,13 +1,19 @@
-- if policy(comment).can_update_or_remove?
-  .pull-right
+.comment_actions.pull-right
+  - if policy(comment).reply?
+    = link_to "Reply", "#",
+              class: "btn btn-small reply_comment_link"
+
+  - if policy(comment).can_update_or_remove?
+
     - if policy(comment).update?
       = link_to edit_comment_path(comment),
-                class: "btn btn-mini",
-                data: { action: "edit_comment", confirm: "Are you sure?" } do
+                class: "btn btn-small",
+                data: { action: "edit_comment" } do
         i.icon-pencil
+
     - if policy(comment).destroy?
       = link_to comment_path(comment),
                 method: :delete,
-                class: "btn btn-mini",
+                class: "btn btn-small",
                 data: { action: "delete_comment", confirm: "Are you sure?" } do
         i.icon-trash

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,9 +1,14 @@
 li.comment id="#{dom_id(comment)}"
   .message
     = govspeak comment.message
-  = render 'comments/action_links', comment: comment
+  = render "comments/action_links", comment: comment
   span.name
     = link_to comment.user, comment.user
     |,
   span.created_at
     = comment.created_at.to_formatted_s(:long)
+  - if policy(comment).reply?
+    - if comment.children.present?
+      ul.comment_children
+        = render comment.children
+    = render 'comments/reply_form', comment: comment

--- a/app/views/comments/_reply_form.html.slim
+++ b/app/views/comments/_reply_form.html.slim
@@ -1,0 +1,6 @@
+.reply_comment_form.hidden
+  = simple_form_for :reply, url: reply_comment_path(comment),
+                            as: :comment,
+                            html: { class: 'form-container' } do |f|
+    = f.input :message, as: :text, label: false
+    = f.button :submit, 'Reply', class: 'btn btn-small btn-success pull-right'

--- a/app/views/comments/show.html.slim
+++ b/app/views/comments/show.html.slim
@@ -1,0 +1,10 @@
+= breadcrumb [comment.commentable.to_s, comment.commentable], "Comment Replies"
+
+.container-fluid
+  .row-fluid
+    .span12
+      h2 Comment Replies
+  .row.comment_replies
+    .span6
+      ul.comments
+        = render comment, from_comment_feed: true

--- a/app/views/content_plans/show.html.slim
+++ b/app/views/content_plans/show.html.slim
@@ -102,4 +102,4 @@
       = render "comments/form"
 
       ul.comments
-        = render content_plan.comments
+        = render content_plan.comments.roots

--- a/app/views/contents/show.html.slim
+++ b/app/views/contents/show.html.slim
@@ -73,4 +73,4 @@
       = render "comments/form", comment: comment
 
       ul.comments
-        = render content.comments
+        = render content.comments.roots

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -33,5 +33,5 @@ h4 Content Plans
   .span4.comments-form
     h4 Comments
     ul.comments
-      - @user.comments.each do |comment|
+      - @user.comments.roots.each do |comment|
        = render comment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,11 @@ ContentPlanner::Application.routes.draw do
 
   resources :tasks
 
-  resources :comments
+  resources :comments do
+    member do
+      post :reply
+    end
+  end
 
   resources :users
 

--- a/db/migrate/20140425124008_add_parent_id_to_comments.rb
+++ b/db/migrate/20140425124008_add_parent_id_to_comments.rb
@@ -1,0 +1,5 @@
+class AddParentIdToComments < ActiveRecord::Migration
+  def change
+    add_reference :comments, :parent, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140430064227) do
+ActiveRecord::Schema.define(version: 20140425124008) do
 
   create_table "comments", force: true do |t|
     t.integer  "user_id"
@@ -20,9 +20,11 @@ ActiveRecord::Schema.define(version: 20140430064227) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "commentable_type", null: false
+    t.integer  "parent_id"
   end
 
   add_index "comments", ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type", using: :btree
+  add_index "comments", ["parent_id"], name: "index_comments_on_parent_id", using: :btree
 
   create_table "content_needs", force: true do |t|
     t.integer "content_id"

--- a/spec/features/comments_reply_spec.rb
+++ b/spec/features/comments_reply_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+feature "Reply on comment" do
+  let!(:user) { create :user, :gds_editor }
+  let!(:content) { create :content }
+  let!(:comment) {
+    create :comment, user: user, commentable: content
+  }
+
+  let(:reply_text) { "Reply message" }
+
+  scenario "User replies on comment" do
+    visit content_path(content)
+    user_can_reply_comment(0, 1)
+  end
+
+  describe "Comment Replies page" do
+    let!(:reply_comment) {
+      create :comment, user: user, commentable: content, parent: comment
+    }
+
+    before {
+      visit content_path(content)
+    }
+
+    scenario "should see comment and replies" do
+      expect_to_see comment.message
+      expect_to_see reply_comment.message
+    end
+
+    scenario "User can reply from this page" do
+      user_can_reply_comment(1, 2)
+    end
+  end
+
+  private
+
+  def user_can_reply_comment(initial_children_count, final_children_count)
+    within(dom_id_selector(comment)) do
+      find(".reply_comment_link").click
+    end
+
+    expect {
+      within(".reply_comment_form") do
+        fill_in "reply[message]", with: reply_text
+        click_on "Reply"
+      end
+    }.to change { comment.reload.children.count }.from(initial_children_count).to(final_children_count)
+  end
+end

--- a/spec/mailers/comment_reply_notification_spec.rb
+++ b/spec/mailers/comment_reply_notification_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe "Comment Reply notification" do
+  let!(:user) { create :user, :gds_editor }
+  let!(:another_user) { create :user, :gds_editor }
+  let!(:content) { create :content }
+  let!(:comment) {
+    create :comment, user: user, commentable: content
+  }
+
+  let(:reply_text) { "Reply message" }
+  let!(:reply_comment) {
+    create :comment, message: reply_text,
+                     user: another_user,
+                     commentable: content,
+                     parent: comment
+  }
+
+  let(:mail) { CommentMailer.reply_notification(reply_comment, user) }
+  let(:subject) { "#{another_user} replied on comment on #{content}" }
+
+  it "renders the headers" do
+    mail.subject.should eq(subject)
+    mail.to.should eq([user.email])
+    mail.from.should eq(["content-planner@digital.cabinet-office.gov.uk"])
+  end
+
+  it "renders the body" do
+    mail.body.encoded.should match(subject)
+    mail.body.encoded.should match(reply_comment.message)
+    mail.body.encoded.should have_link("View", href: comment_url(comment))
+  end
+end


### PR DESCRIPTION
Replying to comments in content planner
https://www.pivotaltracker.com/story/show/68002996
- added base reply comment functionality
- added reply email notification
- added permission policy for reply
- added comment replies page
  - this page displays parent comment and all replies
  - user can add one more reply on this page
  - we will redirect to this page from mailer
- added Rspec checks for:
  - review replies
  - reply from commentable association
  - reply from comment replies page
  - covered reply comment email notification with Rspec
