### PR TITLE
67642438 Content records order and filters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,4 +65,5 @@ group :test do
   gem "simplecov"
   gem "simplecov-rcov"
   gem "launchy"
+  gem "poltergeist"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       xpath (~> 2.0)
     ci_reporter (1.9.0)
       builder (>= 2.1.2)
+    cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -221,6 +222,11 @@ GEM
       ast (~> 1.1)
       slop (~> 3.4, >= 3.4.5)
     plek (1.5.0)
+    poltergeist (1.5.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     polyglot (0.3.3)
     powerpack (0.0.9)
     pry (0.9.12.6)
@@ -344,6 +350,7 @@ GEM
     uniform_notifier (1.4.0)
     warden (1.2.3)
       rack (>= 1.0)
+    websocket-driver (0.3.3)
     xml-simple (1.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -386,6 +393,7 @@ DEPENDENCIES
   mysql2
   paper_trail (>= 3.0.0.rc1)
   plek (>= 1.0.0)
+  poltergeist
   pry
   pry-rails
   pundit

--- a/app/assets/stylesheets/views/contents.css.scss
+++ b/app/assets/stylesheets/views/contents.css.scss
@@ -34,5 +34,11 @@
   }
 }
 
-.inner {
+.contents-search-form {
+  margin-top: 30px;
+  padding-bottom: 40px;
+
+  #search_title, .select2-container {
+    margin-right: 5px;
+  }
 }

--- a/app/controllers/content_plans_controller.rb
+++ b/app/controllers/content_plans_controller.rb
@@ -12,8 +12,11 @@ class ContentPlansController < ApplicationController
   expose(:tasks) {
     content_plan.tasks.includes(:users)
   }
+  expose(:contents_search) {
+    PlanContentsSearch.new(contents_search_params)
+  }
   expose(:contents) {
-    content_plan.contents
+    contents_search.results.page(params[:page])
   }
   expose(:content_records_statuses) {
     contents.pluck(:status).uniq
@@ -87,6 +90,10 @@ class ContentPlansController < ApplicationController
                                          maslow_need_ids: [],
                                          organisation_ids: []
     )
+  end
+
+  def contents_search_params
+    {content_plan_id: content_plan.id}
   end
 
   def authorize_user

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -1,7 +1,15 @@
 class ContentsController < ApplicationController
   expose(:content, attributes: :content_params)
+  expose(:content_plan) { ContentPlan.find(params[:content_plan_id]) }
+  expose(:search) {
+    if params[:content_plan_id].present?
+      PlanContentsSearch.new(contents_search_params)
+    else
+      ContentSearch.new(params[:search])
+    end
+  }
   expose(:contents) {
-    ContentSearch.new(params[:search]).results.order(:ref_no).page(params[:page])
+    search.results.page(params[:page])
   }
   expose(:comment) {
     current_user.comments.build(commentable: content)
@@ -13,10 +21,9 @@ class ContentsController < ApplicationController
     content.tasks.includes(:users)
   }
 
-  before_filter :authorize_user
+  before_filter :authorize_user, except: [:index]
 
   def index
-    @search = ContentSearch.new(params[:search])
   end
 
   def new
@@ -84,6 +91,10 @@ class ContentsController < ApplicationController
         content_plan_ids: []
       )
     end
+  end
+
+  def contents_search_params
+    (params[:search] || {}).merge({content_plan_id: params[:content_plan_id]})
   end
 
   def authorize_user

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -52,6 +52,14 @@ class Content < ActiveRecord::Base
     where id: Organisationable.for_content.where(organisation_id: organisation_id).pluck(:organisationable_id) if organisation_id.present?
   }
 
+  scope :for_status, -> (status) { where status: status }
+  scope :for_title, -> (title) {
+    where("lower(contents.title) LIKE ?", "%#{title.downcase}%")
+  }
+  scope :for_content_plan, -> (content_plan_id) {
+    joins(:content_plans).where("content_plans.id = ?", content_plan_id)
+  }
+
   # Caching
   before_save do
     content_plans.each { |record| record.touch }

--- a/app/searches/plan_contents_search.rb
+++ b/app/searches/plan_contents_search.rb
@@ -1,0 +1,21 @@
+class PlanContentsSearch < Searchlight::Search
+  search_on Content.order(:ref_no)
+
+  searches :content_plan_id, :title, :platform, :status
+
+  def search_content_plan_id
+    search.for_content_plan(content_plan_id)
+  end
+
+  def search_title
+    search.for_title(title)
+  end
+
+  def search_platform
+    search.platform(platform)
+  end
+
+  def search_status
+    search.for_status(status)
+  end
+end

--- a/app/views/content_plans/_contents_block.html.slim
+++ b/app/views/content_plans/_contents_block.html.slim
@@ -1,0 +1,10 @@
+.span8
+  h4
+    | Content Records
+    = link_to "Add content",
+              new_content_path(content_plan_id: content_plan.id),
+              class: "btn btn-mini contents-btn"
+  = render 'contents/search_form'
+  .clearfix
+  .contents_container
+    = render 'contents/list'

--- a/app/views/content_plans/show.html.slim
+++ b/app/views/content_plans/show.html.slim
@@ -63,32 +63,7 @@
           h4 Notes
           = govspeak content_plan.notes
 .row
-  .span8
-      h4
-        | Content Records
-        = link_to "Add content", new_content_path(content_plan_id: content_plan.id), class: "btn btn-mini contents-btn"
-      table.table
-        thead
-          th.title Title
-          th.size Size
-          th.status Status
-          th.platform Platform
-          th.publish_by Publish by
-        tbody
-          - content_plan.contents.each do |content|
-            tr
-              td
-                = link_to content, content
-              td
-                = content.size
-              td
-                = content.status
-              td
-                = link_to content.platform, content.url, rel: "external", target: "_blank"
-              td
-                - if content.publish_by.present?
-                  = l content.publish_by
-
+  = render 'content_plans/contents_block'
 
   .span4.tasks-comments
     .inner

--- a/app/views/contents/_content.html.slim
+++ b/app/views/contents/_content.html.slim
@@ -1,0 +1,12 @@
+tr
+  td
+    = link_to content, content
+  td
+    = content.size
+  td
+    = content.status
+  td
+    = link_to content.platform, content.url, rel: "external", target: "_blank"
+  td
+    - if content.publish_by.present?
+      = l content.publish_by

--- a/app/views/contents/_list.html.slim
+++ b/app/views/contents/_list.html.slim
@@ -1,0 +1,13 @@
+- if contents.present?
+  = paginate contents, params: { controller: 'contents', action: 'index', content_plan_id: content_plan.id }, remote: true
+  table.table
+    thead
+      th.title Title
+      th.size Size
+      th.status Status
+      th.platform Platform
+      th.publish_by Publish by
+    tbody
+      = render contents
+- else
+  p No entries for you search results

--- a/app/views/contents/_search_form.html.slim
+++ b/app/views/contents/_search_form.html.slim
@@ -1,0 +1,21 @@
+= simple_form_for contents_search,
+                  url: contents_path,
+                  html: { class: 'form-inline contents-search-form' },
+                  method: :get,
+                  remote: true do |f|
+  = hidden_field_tag :content_plan_id, content_plan.id
+  = f.input :title, placeholder: "Title",
+                    label: false,
+                    input_html: { class: "pull-left" }
+  = f.input :platform, as: :select,
+                       collection: Content::PLATFORMS,
+                       placeholder: "Platform",
+                       input_html: { class: "select2 pull-left", include_blank: true },
+                       label: false
+  = f.input :status, as: :select,
+                       collection: Content::STATUS,
+                       placeholder: "Status",
+                       input_html: { class: "select2 pull-left", include_blank: true },
+                       label: false
+
+  = f.submit "Search", class: 'btn pull-right'

--- a/app/views/contents/index.html.slim
+++ b/app/views/contents/index.html.slim
@@ -5,26 +5,26 @@
 .row
   .span12
 
-    = form_for(@search, url: contents_path, method: :get, html: { class: 'form-inline search-form' }) do |f|
+    = form_for(search, url: contents_path, method: :get, html: { class: 'form-inline search-form' }) do |f|
       = f.select :organisation_ids,
-                 options_for_select( organisations_options_for_select, @search.organisation_ids ),
+                 options_for_select( organisations_options_for_select, search.organisation_ids ),
                  { include_blank: true },
                  { class: "js-organisations", style: "width:120px" }
       = f.select :content_plan_ids,
-                 options_for_select( ContentPlan.all.map{|c| [c.to_s, c.id]}, @search.content_plan_ids ),
+                 options_for_select( ContentPlan.all.map{|c| [c.to_s, c.id]}, search.content_plan_ids ),
                  { include_blank: true },
                  { placeholder: "Content Plan", style: "width:200px",multiple: true }
       = f.select :need_id,
-                 options_for_select( needs_options_for_select, @search.need_id ),
+                 options_for_select( needs_options_for_select, search.need_id ),
                  { include_blank: true },
                  { class: "js-needs", style: "width:210px" }
       = f.select :user_id,
-                 options_for_select( users_options_for_select, @search.user_id ),
+                 options_for_select( users_options_for_select, search.user_id ),
                  { include_blank: true },
                  { class: "js-users", style: "width:140px"}
       = f.text_field :tag, placeholder: "Tag", class: "js-tags", style: "width:170px"
       = f.select :status,
-                 options_for_select(Content::STATUS, @search.status),
+                 options_for_select(Content::STATUS, search.status),
                  { include_blank: true },
                  { class: "select2", placeholder: "Status", style: "width:100px" }
       = f.submit "Search", class: 'btn'

--- a/app/views/contents/index.js.erb
+++ b/app/views/contents/index.js.erb
@@ -1,0 +1,1 @@
+$(".contents_container").html("<%= j(render('contents/list')) %>");

--- a/spec/features/content_plans/filter_content_records_spec.rb
+++ b/spec/features/content_plans/filter_content_records_spec.rb
@@ -1,0 +1,98 @@
+require "spec_helper"
+
+describe "Content records", %q{
+As a User of the Content Planner
+I want to be able to filter content records in content plan details page
+So that I can find records quickly
+} do
+
+  let!(:user) { create :user, :gds_editor }
+  let!(:content_plan) {
+    c = create(:content_plan, :with_organisation,
+                              :with_need,
+                              :with_user)
+    c.reload
+  }
+
+  let(:content_title) { "First Content" }
+
+  let!(:content) {
+    create :content, title: content_title,
+                     content_plans: [content_plan],
+                     platform: "Whitehall",
+                     status: "Live"
+  }
+
+  let(:another_content_title) { "Second content" }
+  let!(:another_content) {
+    create :content, title: another_content_title,
+                     content_plans: [content_plan],
+                     platform: "Publisher",
+                     status: "Drafting - agency"
+  }
+
+  before {
+   visit content_plan_path(content_plan)
+  }
+
+  describe "ability to filter" do
+    it "should display content records" do
+      expect_to_see content_title
+      expect_to_see another_content_title
+    end
+
+    it "should allow to filter by title", js: true do
+      within(".contents-search-form") do
+        fill_in "search_title", with: content_title[3..5]
+        click_on "Search"
+      end
+
+      expect_to_see content_title
+      expect_to_see_no another_content_title
+
+      within(".contents-search-form") do
+        fill_in "search_title", with: another_content_title
+        click_on "Search"
+      end
+
+      expect_to_see another_content_title
+      expect_to_see_no content_title
+    end
+
+    it "should allow to filter by platform", js: true do
+      within(".contents-search-form") do
+        page.execute_script("$('#search_platform').val('Whitehall')")
+        click_on "Search"
+      end
+
+      expect_to_see content_title
+      expect_to_see_no another_content_title
+
+      within(".contents-search-form") do
+        page.execute_script("$('#search_platform').val('Publisher')")
+        click_on "Search"
+      end
+
+      expect_to_see another_content_title
+      expect_to_see_no content_title
+    end
+
+    it "should allow to filter by status", js: true do
+      within(".contents-search-form") do
+        page.execute_script("$('#search_status').val('Live')")
+        click_on "Search"
+      end
+
+      expect_to_see content_title
+      expect_to_see_no another_content_title
+
+      within(".contents-search-form") do
+        page.execute_script("$('#search_status').val('Drafting - agency')")
+        click_on "Search"
+      end
+
+      expect_to_see another_content_title
+      expect_to_see_no content_title
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,9 @@ require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 require "rspec/autorun"
 
+require "capybara/poltergeist"
+Capybara.javascript_driver = :poltergeist
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
@@ -28,7 +31,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of
@@ -44,12 +47,18 @@ RSpec.configure do |config|
   config.before(:suite) do
     ContentPlanner.needs_api = MockNeedsApi.new
     ContentPlanner.organisations_api = MockOrganisationsApi.new
-    DatabaseCleaner.strategy = :truncation
   end
-  config.before(:each) do
+
+  config.before :each do
+    if Capybara.current_driver == :rack_test
+      DatabaseCleaner.strategy = :transaction
+    else
+      DatabaseCleaner.strategy = :truncation
+    end
     DatabaseCleaner.start
   end
-  config.after(:each) do
+
+  config.after do
     DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67642438
- set order for content records as ref_no asc
- added ajax search filters for title, platfrom and status with pagination
- setup javascript testing via poltergeist
- covered ajax filtering of content records with Rspec tests
