### PR TITLE
Tag list bugfix

### DIFF
--- a/app/decorators/content_base_decorator.rb
+++ b/app/decorators/content_base_decorator.rb
@@ -1,5 +1,5 @@
 class ContentBaseDecorator < ApplicationDecorator
-  def tag_list
+  def tags_list
     object.tags.map(&:name)
   end
 

--- a/app/tasks/correct_wrong_tags.rb
+++ b/app/tasks/correct_wrong_tags.rb
@@ -1,0 +1,24 @@
+class CorrectWrongTags
+  class << self
+    def run
+      ContentPlan.all.each do |content_plan|
+        if content_plan.tags.present?
+          correct_tags!(content_plan)
+        end
+      end
+
+      Content.all.each do |content|
+        if content.tags.present?
+          correct_tags!(content)
+        end
+      end
+    end
+
+    def correct_tags!(instance)
+      current_tag_list = instance.tag_list
+      new_tag_list = current_tag_list.map { |tag| tag.gsub(/["\[\]\\]/, "") }
+      instance.tag_list = new_tag_list.compact.uniq
+      instance.save
+    end
+  end
+end

--- a/app/views/content_plans/index.html.slim
+++ b/app/views/content_plans/index.html.slim
@@ -48,6 +48,6 @@
             td
               = user_needs_links content_plan.need_ids
             td
-              = content_plan_tag_filters content_plan.decorate.tag_list
+              = content_plan_tag_filters content_plan.decorate.tags_list
             td
               = content_plan.due_date

--- a/app/views/content_plans/show.html.slim
+++ b/app/views/content_plans/show.html.slim
@@ -33,7 +33,7 @@
       - if content_plan.tag_list.present?
         dt Tags:
         dd
-          = content_plan_tag_filters content_plan.decorate.tag_list
+          = content_plan_tag_filters content_plan.decorate.tags_list
       - if content_plan.due_date.present?
         dt Due:
         dd

--- a/app/views/contents/index.html.slim
+++ b/app/views/contents/index.html.slim
@@ -62,6 +62,6 @@
             td
               = user_needs_links content.need_ids
             td
-              = content_tag_filters content.decorate.tag_list
+              = content_tag_filters content.decorate.tags_list
             td
               = content.decorate.users_list

--- a/app/views/contents/show.html.slim
+++ b/app/views/contents/show.html.slim
@@ -54,7 +54,7 @@
           - if content.tag_list.present?
             dt Tags:
             dd
-              = content_tag_filters content.decorate.tag_list
+              = content_tag_filters content.decorate.tags_list
           - if content.organisations.any?
             dt Organisations:
             dd

--- a/db/migrate/20140506132706_correct_tags.rb
+++ b/db/migrate/20140506132706_correct_tags.rb
@@ -1,0 +1,5 @@
+class CorrectTags < ActiveRecord::Migration
+  def up
+    Rake::Task['db:correct_tags'].invoke
+  end
+end

--- a/lib/tasks/correct_tags.rake
+++ b/lib/tasks/correct_tags.rake
@@ -1,0 +1,6 @@
+namespace :db do
+  desc "Correct tags"
+  task correct_tags: :environment do
+    CorrectWrongTags.run
+  end
+end


### PR DESCRIPTION
- renamed ContentBaseDecorator.tag_list to tags_list
  It cause error on edit tags (it override ActsAsTaggableOn's tag_list)
  in some places like expose_decorated(:content_plan, attributes: :content_plan_params)
- added rake task which corrects bad tag_lists for ContentPlan and Content
  rake db:correct_tags
