### PR TITLE
[71412882] fix issue with datepicker and turbolinks

### DIFF
--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -1,5 +1,5 @@
 (function() {
-  var taskCheckBoxSubmit;
+  var taskCheckBoxSubmit, datepicker_init;
 
   taskCheckBoxSubmit = function() {
     return $(".js-task-checkbox").change(function() {
@@ -18,6 +18,6 @@
 
   $(document).ready([taskCheckBoxSubmit, datepicker_init]);
 
-  $(document).on("page:load", [taskCheckBoxSubmit, datepicker_init]);
+  $(document).on("page:load", taskCheckBoxSubmit, datepicker_init);
 
 }).call(this);


### PR DESCRIPTION
callbacks for event `page:load` should be separated arguments
[pivotal story](https://www.pivotaltracker.com/s/projects/889184/stories/71412882)
