### PR TITLE
Tidy up dead code

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,6 @@ Bundler.require(:default, Rails.env)
 
 module ContentPlanner
   class Application < Rails::Application
-    require 'content_planner'
 
     # don't generate RSpec tests for views and helpers
     config.generators do |g|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,9 +1,4 @@
 ContentPlanner::Application.configure do
-  require "#{config.root}/spec/support/mock_needs_api"
-  require "#{config.root}/spec/support/mock_organisations_api"
-  require 'gds_api/need_api'
-  require 'gds_api/organisations'
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -42,14 +37,4 @@ ContentPlanner::Application.configure do
 
   # mailer default url options
   config.action_mailer.default_url_options = { host: "http://10.1.1.254:3058/" }
-
-  config.after_initialize do
-    if ENV["USE_API"]
-      ContentPlanner.needs_api = GdsApi::NeedApi.new( Plek.current.find('need-api'), API_CLIENT_CREDENTIALS )
-      ContentPlanner.organisations_api = GdsApi::Organisations.new( Plek.current.find('whitehall-admin') )
-    else
-      ContentPlanner.needs_api = MockNeedsApi.new
-      ContentPlanner.organisations_api = MockOrganisationsApi.new
-    end
-  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,4 @@
 ContentPlanner::Application.configure do
-  require 'gds_api/need_api'
-  require 'gds_api/organisations'
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -86,9 +83,4 @@ ContentPlanner::Application.configure do
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
   config.logstasher.suppress_app_log = true
-
-  config.after_initialize do
-    ContentPlanner.needs_api = GdsApi::NeedApi.new( Plek.current.find('need-api'), API_CLIENT_CREDENTIALS )
-    ContentPlanner.organisations_api = GdsApi::Organisations.new( Plek.current.find('whitehall-admin') )
-  end
 end

--- a/lib/content_planner.rb
+++ b/lib/content_planner.rb
@@ -1,6 +1,0 @@
-module ContentPlanner
-  mattr_accessor :needs_api
-  mattr_accessor :organisations_api
-
-  module_function
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,11 +47,6 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 
-  config.before(:suite) do
-    ContentPlanner.needs_api = MockNeedsApi.new
-    ContentPlanner.organisations_api = MockOrganisationsApi.new
-  end
-
   config.before :each do
     if Capybara.current_driver == :rack_test
       DatabaseCleaner.strategy = :transaction


### PR DESCRIPTION
Now that the orgs and needs are imported via rake tasks:

organisations:import
needs:import

This legacy code does not need to be here.
