### PR TITLE
platform wording amends

### DIFF
--- a/db/migrate/20140723200657_platform_wording_amends.rb
+++ b/db/migrate/20140723200657_platform_wording_amends.rb
@@ -1,0 +1,20 @@
+class PlatformWordingAmends < ActiveRecord::Migration
+  def up
+    # things messed up in 20140421143815_platfrom_wording_changes.rb
+    # should've been:
+    # specialist -> whitehall
+    # mainstream -> publisher
+    #
+    # now:
+    # whitehall -> publisher
+    # publisher -> whitehall
+    whitehall_ids = Content.whitehall.pluck :id
+    publisher_ids = Content.publisher.pluck :id
+    Content.where(id: whitehall_ids).update_all(platform: "Publisher")
+    Content.where(id: publisher_ids).update_all(platform: "Whitehall")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140517002643) do
+ActiveRecord::Schema.define(version: 20140723200657) do
 
   create_table "comments", force: true do |t|
     t.integer  "user_id"


### PR DESCRIPTION
things messed up in `20140421143815_platfrom_wording_changes`. Change wording:
`whitehall -> publisher`
`publisher -> whitehall`
