### PR TITLE
Fixed speed performance issue on index pages

### DIFF
--- a/app/searches/content_plan_search.rb
+++ b/app/searches/content_plan_search.rb
@@ -1,7 +1,5 @@
 class ContentPlanSearch < Searchlight::Search
-  search_on ContentPlan.includes([:content_plan_needs, :contents, :organisationables, :content_plan_users, :tags])
-                       .references(:content_plan_needs, :contents, :organisationables, :content_plan_users, :tags)
-                       .order(:ref_no)
+  search_on ContentPlan.includes([:needs, :organisationables, :contents, :tags, :users]).order(:ref_no)
 
   searches :ref_no, :status, :need_id, :tag, :organisation_ids, :due_date, :user_id
 


### PR DESCRIPTION
The reason is wrong using of combination of
.includes and .references.
With .references option - same SQL loads x10 slower
