### PR TITLE
Remove unicorn config overrides.

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,0 @@
-govuk_defaults = '/etc/govuk/unicorn.rb'
-instance_eval(File.read(govuk_defaults), govuk_defaults) if File.exist?(govuk_defaults)
-
-worker_processes 4


### PR DESCRIPTION
This means that it will use the same defaults as most of the other apps.
Specifically, this will reduce the number of workers to 2 per box in
line with the other publishing app.  This should relieve some of the
memory pressure on the backend servers.
