### PR TITLE
Bump paper_trail gem.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    paper_trail (3.0.3)
+    paper_trail (3.0.6)
       activerecord (>= 3.0, < 5.0)
       activesupport (>= 3.0, < 5.0)
     parser (2.2.0.pre.3)


### PR DESCRIPTION
Version 3.0.3 has been yanked, and is failing to install if not already
present.
