### PR TITLE
Use memcached instead of in-process cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem "gds-api-adapters", "12.2.0"
 gem "govuk_frontend_toolkit", git: "https://github.com/alphagov/govuk_frontend_toolkit_gem.git", submodules: true
 gem "pundit"
 gem "logstasher", '0.4.8'
-gem "lrucache", "0.1.4"
 
 gem "aws-ses", require: "aws/ses"
 gem "airbrake", "3.1.15"

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "gds-api-adapters", "12.2.0"
 gem "govuk_frontend_toolkit", git: "https://github.com/alphagov/govuk_frontend_toolkit_gem.git", submodules: true
 gem "pundit"
 gem "logstasher", '0.4.8'
+gem "dalli", "~> 2.7.2"
 
 gem "aws-ses", require: "aws/ses"
 gem "airbrake", "3.1.15"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     daemons (1.1.9)
+    dalli (2.7.2)
     database_cleaner (1.0.1)
     debug_inspector (0.0.2)
     decent_decoration (0.0.6)
@@ -421,6 +422,7 @@ DEPENDENCIES
   capybara
   ci_reporter
   coffee-rails (~> 4.0.0)
+  dalli (~> 2.7.2)
   database_cleaner (= 1.0.1)
   decent_decoration
   decent_exposure

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,7 +440,6 @@ DEPENDENCIES
   kaminari
   launchy
   logstasher (= 0.4.8)
-  lrucache (= 0.1.4)
   modernizr-rails
   mysql2
   paper_trail (>= 3.0.0.rc1)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ ContentPlanner::Application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = :memory_store
+  config.cache_store = :dalli_store, {:namespace => 'content-planner', :expires_in => 4.hours}
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"


### PR DESCRIPTION
memcached is installed on all the app servers, so it makes sense to use
it.  This will reduce the memory usage of the Rails workers, and allow
workers on a given server to share the cache.
