### PR TITLE
Allow all content plans to be exported

### DIFF
--- a/app/controllers/content_plans_controller.rb
+++ b/app/controllers/content_plans_controller.rb
@@ -44,7 +44,6 @@ class ContentPlansController < ApplicationController
   }
 
   before_filter :authorize_user
-  before_action :require_all_records_to_be_live!, only: :xls_export
 
   def index
     @search = ContentPlanSearch.new(params[:search])

--- a/app/views/content_plans/show.html.slim
+++ b/app/views/content_plans/show.html.slim
@@ -1,8 +1,7 @@
 - if policy(content_plan).edit?
   = link_to "edit", [:edit, content_plan], class: 'btn pull-right'
 = link_to "history", [:versions, content_plan], class: 'btn pull-right history-btn'
-- if all_records_are_live?
-  = link_to "Excel export", xls_export_content_plan_path(content_plan.id), class: 'btn pull-right'
+= link_to "Excel export", xls_export_content_plan_path(content_plan.id), class: 'btn pull-right'
 
 = breadcrumb ["Content Plans", content_plans_path], content_plan.name
 .row

--- a/spec/features/content_plans/excel_export_spec.rb
+++ b/spec/features/content_plans/excel_export_spec.rb
@@ -45,11 +45,6 @@ So that I can have ability to review content plan in excel file
     create(:comment, commentable: content, user: user)
   }
 
-  it "'Excel export' link should not be visible" do
-    visit content_plan_path(content_plan)
-    expect_to_see_no "Excel export"
-  end
-
   describe "all records have been changed to the 'live' status", type: :controller do
     before {
       content_plan.contents.update_all(status: "Live")


### PR DESCRIPTION
Remove the live restriction on exporting content plans
